### PR TITLE
Create composer.json

### DIFF
--- a/Model/Behavior/BigDataBehavior.php
+++ b/Model/Behavior/BigDataBehavior.php
@@ -77,7 +77,7 @@ class BigDataBehavior extends ModelBehavior {
 		}
 
 		$table = Inflector::tableize($this->_Model->name);
-		$fieldNames = array_keys($this->_Model->schema());
+		$fieldNames = array_map(function($n) { return "`$n`"; }, array_keys($this->_Model->schema()));
 
 		$sql = sprintf('INSERT INTO `%s` (%s) VALUES', $table, implode(',', $fieldNames));
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name":"infostreams/cakephp_big_data",
+    "description":"CakePHP BigData plugin",
+    "version":"2.0.0",
+    "type": "cakephp-plugin",
+    "require": {
+        "composer/installers": "*"
+    },
+    "extra": {
+        "installer-name": "BigData"
+    }
+}


### PR DESCRIPTION
Add a 'composer.json' so that this plugin can be installed with composer. Example use in a project that uses this plugin, in that project's `composer.json` file:

```
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/infostreams/cakephp_big_data"
        }
    ],
    "require": {
        "infostreams/cakephp_big_data": "dev-master"
    }
}
```

With that in place, you can install the plugin by doing `composer update`. Preferably, register this plugin with Packagist to make the installation even easier. You should probably also change the package name (inside the composer.json) from `infostreams/cakephp_big_data` to `jmillerdesign/cakephp_big_data` (lowercase, no capitals)
